### PR TITLE
chore: add fallback rpcs to envio as good practice

### DIFF
--- a/envio/config.yaml
+++ b/envio/config.yaml
@@ -2,12 +2,11 @@
 name: envio-indexer
 networks:
 - id: 10143
-  # Optional custom RPC configuration - only add if default indexing (Envio HyperSync) has issues
-  # rpc_config:
-  #   url: https://monad-testnet.g.alchemy.com/v2/M4-LB4BW4V2mMSkYaqi-HwhkZkeg302A
-  #   interval_ceiling: 50
-  #   acceleration_additive: 10
-  #   initial_block_interval: 10
+  rpc: # RPC endpoints as fallback providers for added resillience
+  - url: https://testnet-rpc.monad.xyz
+    for: fallback
+  - url: https://monad-testnet.drpc.org
+    for: fallback    
   start_block: 6294247
   contracts:
   - name: KuruOrderBook


### PR DESCRIPTION
**Motivation:**

As a best practise, there is additional resillience having fallback rpc providers

**Modifications:**

Added publicly available fallback rpc providers to config

**Result:**

Nothing to current behaviour, however improved resilience in the event of unexpected behaviour. 

