### PR TITLE
chore: update `graph-cli` version to latest version

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -11,7 +11,7 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 kuru-subgraph"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.96.0",
+    "@graphprotocol/graph-cli": "0.97.0",
     "@graphprotocol/graph-ts": "0.38.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Motivation:**

Updating `graph-cli` version to the latest release

**Modifications:**

Updated the `graph-cli` versions from `v0.96.0` to `v0.97.0`. 

**Result:**

This change enables use of all the up-to-date features that are included in the [`v0.97.0` release](https://github.com/graphprotocol/graph-tooling/releases/tag/%40graphprotocol%2Fgraph-cli%400.97.0).
